### PR TITLE
Fixes to work with yazi 25.4.8

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Ciarán O'Brien
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/main.lua
+++ b/main.lua
@@ -34,7 +34,9 @@ function M:peek(job)
             { tostring(math.max(0, i - limit)), only_if = tostring(job.file.url), upper_bound = "" }
         )
     else
-        lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
+        -- PREVIEW global not available in yazi 25.4.8
+        lines = lines:gsub("\t", string.rep(" ", 4))
+        -- lines = lines:gsub("\t", string.rep(" ", PREVIEW.tab_size))
         ya.preview_widgets(job, { ui.Text.parse(lines):area(job.area), })
     end
 end


### PR DESCRIPTION
The new yazi update, 25.4.8,  broke the plugin, as there is no more PREVIEW global available. This is my poor solution to it - just hard-code the tab size. I also added a LICENSE file so the plugin can be installed with 'ya'